### PR TITLE
Refactor mongo-seed to only use Dockerfile & remove it from docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ server_logs:
 	docker logs -f ping-server
 
 prepare_db:
-	docker-compose up -d --build --remove-orphans mongo-seed
+	docker build -t mongo-seed ./mongo-seed
+	docker run --network mynet --rm -e MONGO_INITDB_ROOT_USERNAME=root -e MONGO_INITDB_ROOT_PASSWORD=rootpassword mongo-seed
 
 clean:
-	docker compose down
+	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   ping-server:
@@ -47,17 +47,6 @@ services:
       ME_CONFIG_MONGODB_ADMINPASSWORD: rootpassword
       ME_CONFIG_MONGO_DB_SERVER: mongodb_container
       ME_CONFIG_MONGODB_URL: "mongodb://root:rootpassword@mongodb_container:27017/"
-  mongo-seed:
-    build: ./mongo-seed
-    networks:
-      - mynet
-    depends_on:
-      - mongodb_container
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: rootpassword
-    volumes:
-      - mongodb_data_container:/data/db
 networks:
   mynet:
     driver: bridge


### PR DESCRIPTION
- The mongo-seed service is removed from the docker-compose.yml file.
- The mongo-seed service is defined solely in its respective Dockerfile present in the mongo-seed/Dockerfile directory.
- The prepare_db target in the Makefile is modified to build the mongo-seed image and run it as a container with the required environment variables and network settings. The mongo-seed container is removed after the import activity is completed.

Note: The server target in the Makefile still scales down the mongo-seed service by setting its count to 0 (--scale mongo-seed=0) since it is not defined in the docker-compose.yml file anymore.